### PR TITLE
Add hospitalcore as a required module

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -27,6 +27,9 @@
 		<require_module version="1.7">
 			org.openmrs.module.metadatadeploy
 		</require_module>
+		<require_module version="1.5.3-SNAPSHOT">
+			org.openmrs.module.hospitalcore
+		</require_module>
 	</require_modules>
 	<!-- / Required Modules -->
 	


### PR DESCRIPTION
mchapp depends on classes defined in hospitalcore, and fails if this dependency is not defined.