### PR TITLE
Add polyfill for the javascript includes function

### DIFF
--- a/omod/src/main/webapp/pages/main.gsp
+++ b/omod/src/main/webapp/pages/main.gsp
@@ -3,6 +3,7 @@
     ui.includeJavascript("billingui", "moment.js")
     ui.includeJavascript("mchapp", "object-to-query-string.js")
     ui.includeJavascript("mchapp", "drugOrder.js")
+	ui.includeJavascript("mchapp", "includes-polyfill.js")
     ui.includeCss("registration", "onepcssgrid.css")
 %>
 <script type="text/javascript">

--- a/omod/src/main/webapp/resources/scripts/includes-polyfill.js
+++ b/omod/src/main/webapp/resources/scripts/includes-polyfill.js
@@ -1,0 +1,31 @@
+/*
+ * From: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
+ */
+if (!Array.prototype.includes) {
+  Array.prototype.includes = function(searchElement /*, fromIndex*/ ) {
+    'use strict';
+    var O = Object(this);
+    var len = parseInt(O.length, 10) || 0;
+    if (len === 0) {
+      return false;
+    }
+    var n = parseInt(arguments[1], 10) || 0;
+    var k;
+    if (n >= 0) {
+      k = n;
+    } else {
+      k = len + n;
+      if (k < 0) {k = 0;}
+    }
+    var currentElement;
+    while (k < len) {
+      currentElement = O[k];
+      if (searchElement === currentElement ||
+         (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
+        return true;
+      }
+      k++;
+    }
+    return false;
+  };
+}


### PR DESCRIPTION
From [this link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) the `includes function was introduced in es6 so is not supported by older versions.